### PR TITLE
Corrected German language issues

### DIFF
--- a/.homeycompose/flow/conditions/flora_measure_fertility_threshold.json
+++ b/.homeycompose/flow/conditions/flora_measure_fertility_threshold.json
@@ -15,7 +15,7 @@
   "hint": {
     "en": "Use this card to determine if the plant has a correct amount of nutritions.",
     "nl": "Gebruik deze kaart om te bepalen of de plant de juiste hoeveelheid voeding heeft.",
-    "de": "Verwenden Sie diese Karte, um festzustellen, das die Pflanze genug Düngemittel hat.",
+    "de": "Verwenden Sie diese Karte, um festzustellen, ob die Pflanze genug Düngemittel hat.",
     "sv": "Använd detta kort för att kontrollera om plantan har tillräckligt med näring."
   },
   "args": [

--- a/.homeycompose/flow/conditions/flora_measure_moisture_threshold.json
+++ b/.homeycompose/flow/conditions/flora_measure_moisture_threshold.json
@@ -15,7 +15,7 @@
   "hint": {
     "en": "Use this card to determine if the plant has a correct amount of moisture.",
     "nl": "Gebruik deze kaart om te bepalen of de plant de juiste hoeveelheid vocht heeft.",
-    "de": "Verwenden Sie diese Karte, um festzustellen, das die Pflanze genug Wasser hat.",
+    "de": "Verwenden Sie diese Karte, um festzustellen, ob die Pflanze genug Wasser hat.",
     "sv": "Använd detta kort för att säkerställa att plantan har tillräckligt med vatten."
   },
   "args": [

--- a/.homeycompose/flow/conditions/measure_luminance_threshold.json
+++ b/.homeycompose/flow/conditions/measure_luminance_threshold.json
@@ -15,7 +15,7 @@
   "hint": {
     "en": "Use this card to determine if the plant has a correct amount of sunlight.",
     "nl": "Gebruik deze kaart om te bepalen of de plant de juiste hoeveelheid zonlicht heeft.",
-    "de": "Verwenden Sie diese Karte, um festzustellen, das die Pflanze die richtige Menge Sonnenlicht hat.",
+    "de": "Verwenden Sie diese Karte, um festzustellen, ob die Pflanze die richtige Menge Sonnenlicht hat.",
     "sv": "Använd detta kort för att säkerställa att plantan har tillräcklig luminans."
   },
   "args": [

--- a/.homeycompose/flow/conditions/measure_moisture_threshold.json
+++ b/.homeycompose/flow/conditions/measure_moisture_threshold.json
@@ -15,7 +15,7 @@
   "hint": {
     "en": "Use this card to determine if the plant has a correct amount of moisture.",
     "nl": "Gebruik deze kaart om te bepalen of de plant de juiste hoeveelheid vocht heeft.",
-    "de": "Verwenden Sie diese Karte, um festzustellen, das die Pflanze genug Wasser hat.",
+    "de": "Verwenden Sie diese Karte, um festzustellen, ob die Pflanze genug Wasser hat.",
     "sv": "Använd detta kort för att säkerställa att plantan tillräckligt med vatten."
   },
   "args": [

--- a/.homeycompose/flow/conditions/measure_nutrition_threshold.json
+++ b/.homeycompose/flow/conditions/measure_nutrition_threshold.json
@@ -15,7 +15,7 @@
   "hint": {
     "en": "Use this card to determine if the plant has a correct amount of nutritions.",
     "nl": "Gebruik deze kaart om te bepalen of de plant de juiste hoeveelheid voeding heeft.",
-    "de": "Verwenden Sie diese Karte, um festzustellen, das die Pflanze genug Düngemittel hat.",
+    "de": "Verwenden Sie diese Karte, um festzustellen, ob die Pflanze genug Düngemittel hat.",
     "sv": "Använd detta kort för att säkerställa att plantan har tillräckligt med näring."
   },
   "args": [

--- a/.homeycompose/flow/conditions/measure_temperature_threshold.json
+++ b/.homeycompose/flow/conditions/measure_temperature_threshold.json
@@ -15,7 +15,7 @@
   "hint": {
     "en": "Use this card to determine if the plant has a correct temperature.",
     "nl": "Gebruik deze kaart om te bepalen of de plant de juiste temperatuur heeft.",
-    "de": "Verwenden Sie diese Karte, um festzustellen, das die Pflanze eine korrekte Temperatur hat.",
+    "de": "Verwenden Sie diese Karte, um festzustellen, ob die Pflanze eine korrekte Temperatur hat.",
     "sv": "Använd detta kort för att säkerställa att plantan har rätt temperatur."
   },
   "args": [

--- a/.homeycompose/flow/triggers/device_sensor_outside_threshold.json
+++ b/.homeycompose/flow/triggers/device_sensor_outside_threshold.json
@@ -3,7 +3,7 @@
   "title": {
     "en": "Sensor value is outside the configured threshold",
     "nl": "Sensor waarde is buiten de gestelde drempel",
-    "de": "Der Sensorwert liegt außerhab der konfigurierten grenzwerte",
+    "de": "Der Sensorwert liegt außerhab der konfigurierten Grenzwerte",
     "sv": "Sensorns värde är utanför den inställda nivån"
   },
   "tokens": [

--- a/.homeycompose/flow/triggers/device_sensor_threshold_max_exceeds.json
+++ b/.homeycompose/flow/triggers/device_sensor_threshold_max_exceeds.json
@@ -3,7 +3,7 @@
   "title": {
     "en": "Sensor value is above the configured threshold",
     "nl": "Sensor waarde is boven de gestelde drempel",
-    "de": "Der Sensorwert liegt über dem konfigurierten grenzwert",
+    "de": "Der Sensorwert liegt über dem konfigurierten Grenzwert",
     "sv": "Sensorns värde är över det inställda tröskelvärdet"
   },
   "tokens": [

--- a/.homeycompose/flow/triggers/device_sensor_threshold_min_exceeds.json
+++ b/.homeycompose/flow/triggers/device_sensor_threshold_min_exceeds.json
@@ -3,7 +3,7 @@
   "title": {
     "en": "Sensor value is below the configured threshold",
     "nl": "Sensor waarde is beneden de gestelde drempel",
-    "de": "Der Sensorwert liegt unter dem konfigurierten grenzwert",
+    "de": "Der Sensorwert liegt unter dem konfigurierten Grenzwert",
     "sv": "Sensorns värde är under det inställda tröskelvärdet"
   },
   "tokens": [

--- a/.homeycompose/flow/triggers/sensor_outside_threshold.json
+++ b/.homeycompose/flow/triggers/sensor_outside_threshold.json
@@ -3,7 +3,7 @@
   "title": {
     "en": "Sensor value is outside the configured threshold",
     "nl": "Sensor waarde is buiten de gestelde drempel",
-    "de": "Der Sensorwert liegt außerhab der konfigurierten grenzwerte",
+    "de": "Der Sensorwert liegt außerhab der konfigurierten Grenzwerte",
     "sv": "Sensorns värde är utanför det inställda tröskelvärdet"
   },
   "tokens": [

--- a/.homeycompose/flow/triggers/sensor_threshold_max_exceeds.json
+++ b/.homeycompose/flow/triggers/sensor_threshold_max_exceeds.json
@@ -3,7 +3,7 @@
   "title": {
     "en": "Sensor value is above the configured threshold",
     "nl": "Sensor waarde is boven de gestelde drempel",
-    "de": "Der Sensorwert liegt über dem konfigurierten grenzwert",
+    "de": "Der Sensorwert liegt über dem konfigurierten Grenzwert",
     "sv": "Sensorns värde är över det inställda tröskelvärdet"
   },
   "tokens": [

--- a/.homeycompose/flow/triggers/sensor_threshold_min_exceeds.json
+++ b/.homeycompose/flow/triggers/sensor_threshold_min_exceeds.json
@@ -3,7 +3,7 @@
   "title": {
     "en": "Sensor value is below the configured threshold",
     "nl": "Sensor waarde is beneden de gestelde drempel",
-    "de": "Der Sensorwert liegt unter dem konfigurierten grenzwert",
+    "de": "Der Sensorwert liegt unter dem konfigurierten Grenzwert",
     "sv": "Sensorns värde är över det inställda tröskelvärdet"
   },
   "tokens": [

--- a/.homeycompose/flow/triggers/sensor_timeout.json
+++ b/.homeycompose/flow/triggers/sensor_timeout.json
@@ -3,7 +3,7 @@
   "title": {
     "en": "The sensor gives a timeout",
     "nl": "Een sensor geeft een timeout",
-    "de": "Der Sensor gibt eine zeitüberschreitung aus",
+    "de": "Der Sensor gibt eine Zeitüberschreitung aus",
     "sv": "Sensorn ger en timeout"
   },
   "tokens": [
@@ -33,7 +33,7 @@
       "example": {
         "en": "Not in range",
         "nl": "Niet binnen bereik",
-        "de": "Nicht in reichweite",
+        "de": "Nicht in Reichweite",
         "sv": "Inte inom räckhåll"
       }
     }

--- a/drivers/flora/driver.compose.json
+++ b/drivers/flora/driver.compose.json
@@ -109,7 +109,7 @@
                     "hint": {
                         "en": "The minimal threshold value for temperature.",
                         "nl": "De minimale grenswaarde voor temperatuur.",
-                        "de": "Der minimale grenzwert für die Temperatur.",
+                        "de": "Der minimale Grenzwert für die Temperatur.",
                         "sv": "Minsta värde för temperatur."
                     }
                 },
@@ -128,7 +128,7 @@
                     "hint": {
                         "en": "The maximum threshold value for temperature.",
                         "nl": "De maximale grenswaarde voor temperatuur.",
-                        "de": "Der maximale grenzwert für die Temperatur.",
+                        "de": "Der maximale Grenzwert für die Temperatur.",
                         "sv": "Högsta värde för temperatur."
                     }
                 }
@@ -137,10 +137,10 @@
         {
             "type": "group",
             "label": {
-                "en": "Luminance (lux)",
-                "nl": "Lichtintensiteit (lux)",
-                "de": "Helligkeit (lux)",
-                "sv": "Luminans (lux)"
+                "en": "Luminance (lx)",
+                "nl": "Lichtintensiteit (lx)",
+                "de": "Helligkeit (lx)",
+                "sv": "Luminans (lx)"
             },
             "children": [
                 {
@@ -158,7 +158,7 @@
                     "hint": {
                         "en": "The minimal threshold value for luminance.",
                         "nl": "De minimale grenswaarde voor lichtintensiteit.",
-                        "de": "Der minimale grenzwert für die Helligkeit.",
+                        "de": "Der minimale Grenzwert für die Helligkeit.",
                         "sv": "Minsta värdet för luminans."
                     }
                 },
@@ -177,7 +177,7 @@
                     "hint": {
                         "en": "The maximum threshold value for luminance.",
                         "nl": "De maximale grenswaarde voor lichtintensiteit.",
-                        "de": "Der maximale grenzwert für die Helligkeit.",
+                        "de": "Der maximale Grenzwert für die Helligkeit.",
                         "sv": "Högsta värde för luminans."
                     }
                 }
@@ -207,7 +207,7 @@
                     "hint": {
                         "en": "The minimal threshold value for nutrition.",
                         "nl": "De minimale grenswaarde voor voeding.",
-                        "de": "Der minimale grenzwert für den Dünger.",
+                        "de": "Der minimale Grenzwert für den Dünger.",
                         "sv": "Minsta värde för näring."
                     }
                 },
@@ -226,7 +226,7 @@
                     "hint": {
                         "en": "The maximum threshold value for nutrition.",
                         "nl": "De maximale grenswaarde voor voeding.",
-                        "de": "Der maximale grenzwert für den Dünger.",
+                        "de": "Der maximale Grenzwert für den Dünger.",
                         "sv": "Högsta värde för näring."
                     }
                 }
@@ -256,7 +256,7 @@
                     "hint": {
                         "en": "The minimal threshold value for moisture.",
                         "nl": "De minimale grenswaarde voor vochtigheid.",
-                        "de": "Der minimale grenzwert für die Feuchtigkeit.",
+                        "de": "Der minimale Grenzwert für die Feuchtigkeit.",
                         "sv": "Minsta värde för fuktighet."
                     }
                 },
@@ -275,7 +275,7 @@
                     "hint": {
                         "en": "The maximum threshold value for moisture.",
                         "nl": "De maximale grenswaarde voor vochtigheid.",
-                        "de": "Der maximale grenzwert für die Feuchtigkeit.",
+                        "de": "Der maximale Grenzwert für die Feuchtigkeit.",
                         "sv": "Högsta värde för fuktighet."
                     }
                 }

--- a/drivers/ropot/driver.compose.json
+++ b/drivers/ropot/driver.compose.json
@@ -65,7 +65,7 @@
                     "label": {
                         "en": "Last updated",
                         "nl": "Laatste update",
-                        "de": "Letzte aktualisierung",
+                        "de": "Letzte Aktualisierung",
                         "sv": "Senast uppdaterad"
                     },
                     "value": ""
@@ -76,7 +76,7 @@
                     "label": {
                         "en": "Device uuid address",
                         "nl": "Apparaat uuid adres",
-                        "de": "Geräte uuid adresse",
+                        "de": "Geräte uuid Adresse",
                         "sv": "Enhetens uuid-adress"
                     },
                     "value": ""

--- a/locales/de.json
+++ b/locales/de.json
@@ -45,13 +45,13 @@
 	},
 	"measure_luminance": {
 	  "name": "Helligkeit",
-	  "suffix": " lux",
-	  "changed": "Die Helligkeit hat sich auf __value__ lux geändert.",
-	  "device_changed": "Die Helligkeit von `__plant__` hat sich geändert auf: __value__ lux.",
-	  "device_updated": "Die Helligkeit von `__plant__` wurde aktualisiert auf: __value__ lux.",
+	  "suffix": " lx",
+	  "changed": "Die Helligkeit hat sich auf __value__ lx geändert.",
+	  "device_changed": "Die Helligkeit von `__plant__` hat sich geändert auf: __value__ lx.",
+	  "device_updated": "Die Helligkeit von `__plant__` wurde aktualisiert auf: __value__ lx.",
 	  "threshold": {
-		"min": "Die Helligkeit (__value__ lux) von `__plant__` ist zu niedrig. Diese muss mindestens __min__ lux betragen.",
-		"max": "Die Helligkeit (__value__ lux) von `__plant__` ist zu hoch. Diese darf maximal __max__ lux betragen."
+		"min": "Die Helligkeit (__value__ lx) von `__plant__` ist zu niedrig. Diese muss mindestens __min__ lx betragen.",
+		"max": "Die Helligkeit (__value__ lx) von `__plant__` ist zu hoch. Diese darf maximal __max__ lx betragen."
 	  }
 	},
 	"measure_nutrition": {
@@ -78,9 +78,9 @@
 	},
 	"measure_battery": {
 	  "name": "Batterie",
-	  "changed": "Die Batteriestärke hat sich auf __value__% geändert.",
-	  "device_changed": "Die Batteriestärke von `__plant__` hat sich geändert auf: __value__%.",
-	  "device_updated": "Die Batteriestärke von `__plant__` wurde aktualisiert auf: __value__%."
+	  "changed": "Die Batterieladung hat sich auf __value__% geändert.",
+	  "device_changed": "Die Batterieladung von `__plant__` hat sich geändert auf: __value__%.",
+	  "device_updated": "Die Batterieladung von `__plant__` wurde aktualisiert auf: __value__%."
 	}
   }
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -45,13 +45,13 @@
 	},
 	"measure_luminance": {
 	  "name": "sunlight",
-	  "suffix": " lux",
-	  "changed": "The sunlight is changed to: __value__ lux.",
-	  "device_changed": "The sunlight of `__plant__` is changed to: __value__ lux.",
-	  "device_updated": "The sunlight of `__plant__` is updated to: __value__ lux.",
+	  "suffix": " lx",
+	  "changed": "The sunlight is changed to: __value__ lx.",
+	  "device_changed": "The sunlight of `__plant__` is changed to: __value__ lx.",
+	  "device_updated": "The sunlight of `__plant__` is updated to: __value__ lx.",
 	  "threshold": {
-		"min": "The sunlight (__value__ lux) of `__plant__` is too low. This must be at least __min__ lux.",
-		"max": "The sunlight (__value__ lux) of `__plant__` is too high. This must be a maximum of __max__ lux."
+		"min": "The sunlight (__value__ lx) of `__plant__` is too low. This must be at least __min__ lx.",
+		"max": "The sunlight (__value__ lx) of `__plant__` is too high. This must be a maximum of __max__ lx."
 	  }
 	},
 	"measure_nutrition": {

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -45,13 +45,13 @@
 	},
 	"measure_luminance": {
 	  "name": "lichtintensiteit",
-	  "suffix": " lux",
-	  "changed": "De lichtintensiteit is verandert naar: __value__ lux.",
-	  "device_changed": "De lichtintensiteit van `__plant__` is verandert naar: __value__ lux.",
-	  "device_updated": "De lichtintensiteit van `__plant__` is geupdate naar: __value__ lux.",
+	  "suffix": " lx",
+	  "changed": "De lichtintensiteit is verandert naar: __value__ lx.",
+	  "device_changed": "De lichtintensiteit van `__plant__` is verandert naar: __value__ lx.",
+	  "device_updated": "De lichtintensiteit van `__plant__` is geupdate naar: __value__ lx.",
 	  "threshold": {
-		"min": "De lichtintensiteit (__value__ lux) van `__plant__` is te laag. Deze moet minimaal __min__ lux zijn.",
-		"max": "De lichtintensiteit (__value__ lux) van `__plant__` is te hoog. Deze moet maximaal __max__ lux zijn."
+		"min": "De lichtintensiteit (__value__ lx) van `__plant__` is te laag. Deze moet minimaal __min__ lx zijn.",
+		"max": "De lichtintensiteit (__value__ lx) van `__plant__` is te hoog. Deze moet maximaal __max__ lx zijn."
 	  }
 	},
 	"measure_nutrition": {

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -45,13 +45,13 @@
 		},
 		"measure_luminance": {
 			"name": "luminans",
-			"suffix": " lux",
-			"changed": "Luminansen har ändrats till: __value__ lux.",
-			"device_changed": "Luminansen för `__plant__` har ändrats till: __value__ lux.",
-			"device_updated": "Luminansen för `__plant__` har uppdaterats till: __value__ lux.",
+			"suffix": " lx",
+			"changed": "Luminansen har ändrats till: __value__ lx.",
+			"device_changed": "Luminansen för `__plant__` har ändrats till: __value__ lx.",
+			"device_updated": "Luminansen för `__plant__` har uppdaterats till: __value__ lx.",
 			"threshold": {
-				"min": "Luminansen (__value__ lux) för `__plant__` är för lågt. Det bör vara minst __min__ lux.",
-				"max": "Luminansen (__value__ lux) för `__plant__` är för högt. Det bör vara som mest __max__ lux."
+				"min": "Luminansen (__value__ lx) för `__plant__` är för lågt. Det bör vara minst __min__ lx.",
+				"max": "Luminansen (__value__ lx) för `__plant__` är för högt. Det bör vara som mest __max__ lx."
 			}
 		},
 		"measure_nutrition": {


### PR DESCRIPTION
Correction of grammatical and spelling mistakes.
Also changed "lux" into "lx" in the en/nl/sv/de.json files.
Like °C or %, is lx the SI unit sign. "Lux" is the unit name, comparable to "temperature" or "humidity". I hope this was ok for you.

And I hope it works now. If not, please let me know.