### PR TITLE
Support for device update from external MQTT message

### DIFF
--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -1,6 +1,6 @@
 {
   "id": "com.mi.flora",
-  "version": "4.1.3",
+  "version": "5.0.0",
   "compatibility": ">=5.0.0",
   "brandColor": "#02988c",
   "sdk": 3,

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -1,6 +1,6 @@
 {
   "id": "com.mi.flora",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "compatibility": ">=5.0.0",
   "brandColor": "#02988c",
   "sdk": 3,

--- a/.homeycompose/flow/actions/update_mqtt.json
+++ b/.homeycompose/flow/actions/update_mqtt.json
@@ -1,0 +1,37 @@
+{
+  "id": "update_mqtt",
+  "title": {
+    "en": "Synchronise all sensor values from MQTT message",
+    "nl": "Synchroniseer alle sensor waarden van MQTT bericht",
+    "de": "Synchronisiere alle Sensorwerte aus MQTT-Nachricht",
+    "sv": "Synkronisera alla sensorers värden från MQTT-meddelande"
+  },
+  "titleFormatted": {
+    "en": "Synchronise all sensor values from MQTT message [[payload]] of topic [[topic]]",
+    "nl": "Synchroniseer alle sensor waarden van MQTT bericht [[payload]] van onderwerp [[topic]]",
+    "de": "Synchronisiere alle Sensorwerte aus MQTT-Nachricht [[payload]] des Themas [[topic]]",
+    "sv": "Synkronisera alla sensorers värden från MQTT-meddelande [[payload]] av ämne [[topic]]"
+  },
+  "args": [
+    {
+      "name": "topic",
+      "type": "text",
+      "title": {
+        "en": "MQTT topic",
+        "nl": "MQTT onderwerp",
+        "de": "MQTT-Thema",
+        "sv": "MQTT-ämne"
+      }
+    },
+    {
+      "name": "payload",
+      "type": "text",
+      "title": {
+        "en": "MQTT payload",
+        "nl": "MQTT payload",
+        "de": "MQTT-Nutzlast",
+        "sv": "MQTT-payload"
+      }
+    }
+  ]
+}

--- a/app.js
+++ b/app.js
@@ -46,7 +46,6 @@ module.exports = class HomeyMiFlora extends Homey.App {
       }
     });
 
-    this.MQTTTopicToMac = {};
     this.updateMQTT.registerRunListener(async args => {
       try {
         return Promise.resolve(await this._updateMQTT(args.topic, args.payload));
@@ -434,37 +433,37 @@ module.exports = class HomeyMiFlora extends Homey.App {
       Object.values(data).forEach(entry => {
         const topic = entry.topic.trim();
         const mac = entry.mac;
-        console.log('Registering MQTT device mac:', mac, 'topic:', topic);
-        this.MQTTTopicToMac[topic] = mac;
+        console.log('Matching mac:', mac, 'topic:', topic);
+        const device = this.devices.find(device => device.getData().mac === mac);
+        if (device) {
+          console.log('Found device name:', device.getName());
+          device.setStoreValue('mqtt_topic', topic);
+        }
       });
     } else {
       console.log('MQTT device message topic:', topic, 'message:', data);
-      const mac = this.MQTTTopicToMac[topic];
-      if (mac) {
-        console.log('Trying to update device mac:', mac, 'data:', data);
-        const device = this.devices.find(device => device.getData().mac === mac);
-        if (device) {
-          console.log('Updating device from MQTT', device.getName(), data);
-          if (data.hasOwnProperty('temperature')) {
-            device.updateCapabilityValue('measure_temperature', data.temperature);
-            console.log('Updating temperature:', data.temperature);
-          }
-          if (data.hasOwnProperty('light')) {
-            device.updateCapabilityValue('measure_luminance', data.light);
-            console.log('Updating light:', data.light);
-          }
-          if (data.hasOwnProperty('moisture')) {
-            device.updateCapabilityValue('measure_moisture', data.moisture);
-            console.log('Updating moisture:', data.moisture);
-          }
-          if (data.hasOwnProperty('conductivity')) {
-            device.updateCapabilityValue('measure_nutrition', data.conductivity);
-            console.log('Updating conductivity:', data.conductivity);
-          }
-          if (data.hasOwnProperty('battery')) {
-            device.updateCapabilityValue('measure_battery', data.battery);
-            console.log('Updating battery:', data.battery);
-          }
+      const device = this.devices.find(device => device.getStoreValue('mqtt_topic') === topic);
+      if (device) {
+        console.log('Found device:', device.getName());
+        if (data.hasOwnProperty('temperature')) {
+          device.updateCapabilityValue('measure_temperature', data.temperature);
+          console.log('Updating temperature:', data.temperature);
+        }
+        if (data.hasOwnProperty('light')) {
+          device.updateCapabilityValue('measure_luminance', data.light);
+          console.log('Updating light:', data.light);
+        }
+        if (data.hasOwnProperty('moisture')) {
+          device.updateCapabilityValue('measure_moisture', data.moisture);
+          console.log('Updating moisture:', data.moisture);
+        }
+        if (data.hasOwnProperty('conductivity')) {
+          device.updateCapabilityValue('measure_nutrition', data.conductivity);
+          console.log('Updating conductivity:', data.conductivity);
+        }
+        if (data.hasOwnProperty('battery')) {
+          device.updateCapabilityValue('measure_battery', data.battery);
+          console.log('Updating battery:', data.battery);
         }
       }
     }

--- a/app.js
+++ b/app.js
@@ -36,10 +36,20 @@ module.exports = class HomeyMiFlora extends Homey.App {
     this.deviceSensorOutsideThreshold = this.homey.flow.getDeviceTriggerCard('device_sensor_outside_threshold');
     this.updateDeviceAction = this.homey.flow.getActionCard('update_device');
     this.update = this.homey.flow.getActionCard('update');
+    this.updateMQTT = this.homey.flow.getActionCard('update_mqtt');
 
     this.update.registerRunListener(async () => {
       try {
         return Promise.resolve(await this._synchroniseSensorData());
+      } catch (error) {
+        return Promise.reject(error);
+      }
+    });
+
+    this.MQTTTopicToMac = {};
+    this.updateMQTT.registerRunListener(async args => {
+      try {
+        return Promise.resolve(await this._updateMQTT(args.topic, args.payload));
       } catch (error) {
         return Promise.reject(error);
       }
@@ -251,6 +261,7 @@ module.exports = class HomeyMiFlora extends Homey.App {
         firmware_version: firmwareVersion,
         last_updated: new Date().toISOString(),
         uuid: device.getData().uuid,
+        mac: device.getData().mac,
       });
 
       console.log({
@@ -258,6 +269,7 @@ module.exports = class HomeyMiFlora extends Homey.App {
         last_updated: new Date().toISOString(),
         uuid: device.getData().uuid,
         battery: batteryValue,
+        mac: device.getData().mac,
       });
 
       console.log('call disconnectPeripheral');
@@ -381,7 +393,7 @@ module.exports = class HomeyMiFlora extends Homey.App {
       throw new Error('Synchronisation already in progress, wait for it to be complete.');
     }
 
-    let { devices } = this;
+    let {devices} = this;
 
     const debugging = false;
     if (debugging) {
@@ -407,6 +419,55 @@ module.exports = class HomeyMiFlora extends Homey.App {
         this.syncInProgress = false;
         throw new Error(error);
       });
+  }
+
+  /**
+   * @private
+   *
+   * update devices from MQTT message
+   */
+  async _updateMQTT(topic, payload) {
+    topic = topic.trim();
+    const data = JSON.parse(payload);
+    if (topic === 'miflora/$announce') {
+      console.log('MQTT announce message:', data);
+      Object.values(data).forEach(entry => {
+        const topic = entry.topic.trim();
+        const mac = entry.mac;
+        console.log('Registering MQTT device mac:', mac, 'topic:', topic);
+        this.MQTTTopicToMac[topic] = mac;
+      });
+    } else {
+      console.log('MQTT device message topic:', topic, 'message:', data);
+      const mac = this.MQTTTopicToMac[topic];
+      if (mac) {
+        console.log('Trying to update device mac:', mac, 'data:', data);
+        const device = this.devices.find(device => device.getData().mac === mac);
+        if (device) {
+          console.log('Updating device from MQTT', device.getName(), data);
+          if (data.hasOwnProperty('temperature')) {
+            device.updateCapabilityValue('measure_temperature', data.temperature);
+            console.log('Updating temperature:', data.temperature);
+          }
+          if (data.hasOwnProperty('light')) {
+            device.updateCapabilityValue('measure_luminance', data.light);
+            console.log('Updating light:', data.light);
+          }
+          if (data.hasOwnProperty('moisture')) {
+            device.updateCapabilityValue('measure_moisture', data.moisture);
+            console.log('Updating moisture:', data.moisture);
+          }
+          if (data.hasOwnProperty('conductivity')) {
+            device.updateCapabilityValue('measure_nutrition', data.conductivity);
+            console.log('Updating conductivity:', data.conductivity);
+          }
+          if (data.hasOwnProperty('battery')) {
+            device.updateCapabilityValue('measure_battery', data.battery);
+            console.log('Updating battery:', data.battery);
+          }
+        }
+      }
+    }
   }
 
   /**
@@ -448,7 +509,7 @@ module.exports = class HomeyMiFlora extends Homey.App {
     if (this.syncInProgress) {
       throw new Error(this.homey.__('pair.error.ble-unavailable'));
     }
-    const { version } = this.homey.manifest;
+    const {version} = this.homey.manifest;
     const devices = [];
     let index = driver.getDevices() ? driver.getDevices().length : 0;
     const currentUuids = [];
@@ -471,11 +532,16 @@ module.exports = class HomeyMiFlora extends Homey.App {
                 id: advertisement.id,
                 uuid: advertisement.uuid,
                 address: advertisement.uuid,
+                mac: advertisement.address,
                 name: advertisement.name,
                 type: advertisement.type,
                 version: `v${version}`,
               },
-              settings: { uuid: advertisement.uuid, ...driver.getDefaultSettings() },
+              settings: {
+                uuid: advertisement.uuid,
+                mac: advertisement.address,
+                ...driver.getDefaultSettings()
+              },
               capabilities: driver.getSupportedCapabilities(),
             });
           }

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "_comment": "This file is generated. Please edit .homeycompose/app.json instead.",
   "id": "com.mi.flora",
-  "version": "4.1.3",
+  "version": "5.0.0",
   "compatibility": ">=5.0.0",
   "brandColor": "#02988c",
   "sdk": 3,
@@ -1148,6 +1148,43 @@
             }
           }
         ]
+      },
+      {
+        "id": "update_mqtt",
+        "title": {
+          "en": "Synchronise all sensor values from MQTT message",
+          "nl": "Synchroniseer alle sensor waarden van MQTT bericht",
+          "de": "Synchronisiere alle Sensorwerte aus MQTT-Nachricht",
+          "sv": "Synkronisera alla sensorers värden från MQTT-meddelande"
+        },
+        "titleFormatted": {
+          "en": "Synchronise all sensor values from MQTT message [[payload]] of topic [[topic]]",
+          "nl": "Synchroniseer alle sensor waarden van MQTT bericht [[payload]] van onderwerp [[topic]]",
+          "de": "Synchronisiere alle Sensorwerte aus MQTT-Nachricht [[payload]] des Themas [[topic]]",
+          "sv": "Synkronisera alla sensorers värden från MQTT-meddelande [[payload]] av ämne [[topic]]"
+        },
+        "args": [
+          {
+            "name": "topic",
+            "type": "text",
+            "title": {
+              "en": "MQTT topic",
+              "nl": "MQTT onderwerp",
+              "de": "MQTT-Thema",
+              "sv": "MQTT-ämne"
+            }
+          },
+          {
+            "name": "payload",
+            "type": "text",
+            "title": {
+              "en": "MQTT payload",
+              "nl": "MQTT payload",
+              "de": "MQTT-Nutzlast",
+              "sv": "MQTT-payload"
+            }
+          }
+        ]
       }
     ]
   },
@@ -1238,6 +1275,17 @@
                 "nl": "Apparaat uuid adres",
                 "de": "Geräte uuid Adresse",
                 "sv": "Enhetens uuid-adress"
+              },
+              "value": ""
+            },
+            {
+              "id": "mac",
+              "type": "label",
+              "label": {
+                "en": "Device MAC address",
+                "nl": "Apparaat MAC adres",
+                "de": "Geräte MAC Adresse",
+                "sv": "Enhetens MAC-adress"
               },
               "value": ""
             }
@@ -1564,6 +1612,17 @@
                 "sv": "Enhetens uuid-adress"
               },
               "value": ""
+            },
+            {
+              "id": "mac",
+              "type": "label",
+              "label": {
+                "en": "Device MAC address",
+                "nl": "Apparaat MAC adres",
+                "de": "Geräte MAC Adresse",
+                "sv": "Enhetens MAC-adress"
+              },
+              "value": ""
             }
           ]
         },
@@ -1883,6 +1942,17 @@
                 "nl": "Apparaat uuid adres",
                 "de": "Geräte uuid Adresse",
                 "sv": "Enhetens uuid-adress"
+              },
+              "value": ""
+            },
+            {
+              "id": "mac",
+              "type": "label",
+              "label": {
+                "en": "Device MAC address",
+                "nl": "Apparaat MAC adres",
+                "de": "Geräte MAC Adresse",
+                "sv": "Enhetens MAC-adress"
               },
               "value": ""
             }

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "_comment": "This file is generated. Please edit .homeycompose/app.json instead.",
   "id": "com.mi.flora",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "compatibility": ">=5.0.0",
   "brandColor": "#02988c",
   "sdk": 3,

--- a/drivers/flora-max/driver.compose.json
+++ b/drivers/flora-max/driver.compose.json
@@ -86,6 +86,17 @@
                         "sv": "Enhetens uuid-adress"
                     },
                     "value": ""
+                },
+                {
+                    "id": "mac",
+                    "type": "label",
+                    "label": {
+                        "en": "Device MAC address",
+                        "nl": "Apparaat MAC adres",
+                        "de": "Geräte MAC Adresse",
+                        "sv": "Enhetens MAC-adress"
+                    },
+                    "value": ""
                 }
             ]
         },

--- a/drivers/flora/driver.compose.json
+++ b/drivers/flora/driver.compose.json
@@ -86,6 +86,17 @@
                         "sv": "Enhetens uuid-adress"
                     },
                     "value": ""
+                },
+                {
+                    "id": "mac",
+                    "type": "label",
+                    "label": {
+                        "en": "Device MAC address",
+                        "nl": "Apparaat MAC adres",
+                        "de": "Geräte MAC Adresse",
+                        "sv": "Enhetens MAC-adress"
+                    },
+                    "value": ""
                 }
             ]
         },

--- a/drivers/ropot/driver.compose.json
+++ b/drivers/ropot/driver.compose.json
@@ -83,6 +83,17 @@
                         "sv": "Enhetens uuid-adress"
                     },
                     "value": ""
+                },
+                {
+                    "id": "mac",
+                    "type": "label",
+                    "label": {
+                        "en": "Device MAC address",
+                        "nl": "Apparaat MAC adres",
+                        "de": "Geräte MAC Adresse",
+                        "sv": "Enhetens MAC-adress"
+                    },
+                    "value": ""
                 }
             ]
         },


### PR DESCRIPTION
Hello,

This commit doesn't change behavior of devices but adds single flow for experienced users - to update device capabilities values via MQTT topic + message. With combination of https://github.com/ThomDietrich/miflora-mqtt-daemon and https://homey.app/en-nl/app/net.weejewel.mqttserver/MQTT-Server/ you can easily update devices not within bluetooth range.